### PR TITLE
fix: _constants and aamarpay.py fix for json payload

### DIFF
--- a/aamarpay/_constants.py
+++ b/aamarpay/_constants.py
@@ -1,5 +1,5 @@
-sandBoxUrl = 'https://sandbox.aamarpay.com/index.php'
-productionUrl = 'https://secure.aamarpay.com/index.php'
+sandBoxUrl = 'https://sandbox.aamarpay.com/jsonpost.php'
+productionUrl = 'https://secure.aamarpay.com/jsonpost.php'
 succesUrl = 'https://example.com/payment/confirm'
 failUrl = 'https://example.com/payment/fail'
 cancelUrl = 'https://example.com/payment/cancel'

--- a/aamarpay/aamarpay.py
+++ b/aamarpay/aamarpay.py
@@ -69,8 +69,11 @@ class aamarPay:
                 "cus_phone": self.customerMobile,
                 "type": "json"
             }
+            # takes a JSON-formatted string
             response = requests.post(
-                const.sandBoxUrl if self.isSandbox else const.productionUrl, payload)
+                const.sandBoxUrl if self.isSandbox else const.productionUrl,
+                data=json.dumps(payload)
+            )
             parseRes = json.loads(response.text)
             if response.status_code == 200:
                 if type(parseRes) is not Str and "payment_url" in parseRes:


### PR DESCRIPTION
## What?
bugfix for the payload in the http request 
## Why?
payload was previously given in a python dict format, and throwing errors
## How?
payload has been converted to a JSON-formatted string with json.dumps()
## Anything Else?
Hope the future devs will be able to save some time

Thanks